### PR TITLE
Simplified CMake handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,8 @@
 # Lightweight GPS (lwgps) CMake support
 ################################################################################
 # The lwgps library can be configured with a lwgps_opts.h file.
-# If such a file is used, the user should set the LWGPS_CONFIG_PATH path variable where
-# the configuration file is located so that is is included properly.
+# If such a file is used, the user should have the path containing this file
+# in the target include directories in an upper CMakeLists.txt
 # 
 # Other than that, only two steps are necessary to compile and link against LWGPS:
 # 1. Use add_subdirectory to add the lwgps folder

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,29 +11,10 @@
 ################################################################################
 cmake_minimum_required(VERSION 3.13)
 
-set(LIB_LWGPS_NAME lwgps)
-
-add_library(${LIB_LWGPS_NAME})
-
-add_subdirectory(${LIB_LWGPS_NAME})
-add_subdirectory(examples)
-
-# The project CMakeLists can set a LWGPS_CONFIG_PATH path including the lwgps_opts.h file
-# and add it.
-if(NOT LWGPS_CONFIG_PATH)
-    message(STATUS "Lightweight GPS configuration path not set.")
+set(LWGPS_LIB_NAME LwGPS)
+set(LWGPS_LIB_TARGET ${LIB_LWGPS_NAME}::${LIB_LWGPS_NAME})
+if(NOT (TARGET ${LWGPS_LIB_TARGET}))
+    add_library(${LWGPS_LIB_TARGET} INTERFACE IMPORTED)
+    target_sources(${LWGPS_LIB_TARGET} INTERFACE "lwgps/src/lwgps/lwgps.c")
+    target_include_directories(${LWGPS_LIB_TARGET} INTERFACE "lwgps/src/include/lwgps")
 endif()
-
-# Extract the absolute path of the provided configuration path
-if(IS_ABSOLUTE ${LWGPS_CONFIG_PATH})
-    set(LWGPS_CONFIG_PATH_ABSOLUTE ${LWGPS_CONFIG_PATH})
-else()
-    get_filename_component(LWGPS_CONFIG_PATH_ABSOLUTE
-        ${LWGPS_CONFIG_PATH} REALPATH BASE_DIR ${CMAKE_SOURCE_DIR}
-    )
-endif()
-
-target_include_directories(${LIB_LWGPS_NAME} PRIVATE
-    ${LWGPS_CONFIG_PATH_ABSOLUTE}
-)
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,10 +11,9 @@
 ################################################################################
 cmake_minimum_required(VERSION 3.13)
 
-set(LWGPS_LIB_NAME LwGPS)
-set(LWGPS_LIB_TARGET ${LIB_LWGPS_NAME}::${LIB_LWGPS_NAME})
-if(NOT (TARGET ${LWGPS_LIB_TARGET}))
-    add_library(${LWGPS_LIB_TARGET} INTERFACE IMPORTED)
-    target_sources(${LWGPS_LIB_TARGET} INTERFACE "lwgps/src/lwgps/lwgps.c")
-    target_include_directories(${LWGPS_LIB_TARGET} INTERFACE "lwgps/src/include/lwgps")
+set(LWGPS_LIB_NAME lwgps)
+if(NOT (TARGET ${LWGPS_LIB_NAME}))
+    add_library(${LWGPS_LIB_NAME} INTERFACE)
+    target_sources(${LWGPS_LIB_NAME} INTERFACE "lwgps/src/lwgps/lwgps.c")
+    target_include_directories(${LWGPS_LIB_NAME} INTERFACE "lwgps/src/include")
 endif()

--- a/lwgps/src/CMakeLists.txt
+++ b/lwgps/src/CMakeLists.txt
@@ -1,3 +1,0 @@
-add_subdirectory(include)
-add_subdirectory(lwgps)
-

--- a/lwgps/src/include/CMakeLists.txt
+++ b/lwgps/src/include/CMakeLists.txt
@@ -1,7 +1,0 @@
-target_include_directories(${LIB_LWGPS_NAME} INTERFACE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-)
-
-target_include_directories(${LIB_LWGPS_NAME} PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
-)

--- a/lwgps/src/include/lwgps/CMakeLists.txt
+++ b/lwgps/src/include/lwgps/CMakeLists.txt
@@ -1,3 +1,0 @@
-target_sources(${LIB_LWGPS_NAME} PRIVATE
-    lwgps.c
-)

--- a/lwgps/src/lwgps/CMakeLists.txt
+++ b/lwgps/src/lwgps/CMakeLists.txt
@@ -1,3 +1,0 @@
-target_sources(${LIB_LWGPS_NAME} PRIVATE
-    lwgps.c
-)


### PR DESCRIPTION
In the previous version, LwGPS was built as a static library.
I think it is better if it is an INTERFACE target instead. This makes the `CMakeLists.txt` file significantly simpler and  allows users to supply the build flags / defines / optimizations themselves. Users also don't have to set a specific variable to point to the `lwgps_opts.h` include path now, it is sufficient to put it in some application include path.