### PR TITLE
prv_parse_float_number: remove implicit promotion to double

### DIFF
--- a/lwgps/src/lwgps/lwgps.c
+++ b/lwgps/src/lwgps/lwgps.c
@@ -121,7 +121,7 @@ prv_parse_float_number(lwgps_t* gh, const char* t) {
     }
     while (CIN(*t)) { /* Get the power */
         value = value * (lwgps_float_t)10 + CTN(*t);
-        power *= 10.0;
+        power *= (lwgps_float_t)10.0;
         ++t;
     }
     return sign * value / power;


### PR DESCRIPTION
The exact GCC error being fixed:

lwgps/lwgps/src/lwgps/lwgps.c:124:15: error: implicit conversion from 'lwgps_float_t' {aka 'float'} to 'double' to match other operand of binary expression [-Werror=double-promotion]